### PR TITLE
Use local system time

### DIFF
--- a/src/cron.ts
+++ b/src/cron.ts
@@ -23,6 +23,7 @@ export interface MongoCronCfg {
   intervalFieldPath?: string;
   repeatUntilFieldPath?: string;
   autoRemoveFieldPath?: string;
+  useLocalTime?: boolean; // Uses either UTC or local system time to evaluate intervals
 }
 
 /**
@@ -50,8 +51,14 @@ export class MongoCron {
       intervalFieldPath: 'interval',
       repeatUntilFieldPath: 'repeatUntil',
       autoRemoveFieldPath: 'autoRemove',
+      useLocalTime: false,
       ...config,
     };
+    if (this.config.useLocalTime) {
+      later.date.localTime();
+    } else {
+      later.date.UTC();
+    }
   }
 
   /**


### PR DESCRIPTION
Allow via option boolean `useLocalTime` to use the local system time instead of UTC for intervals.
Maybe does not solve the timezone/summertime issue for everyone but for me this should do it.
closes #8

To test you can use the following example and check the sleepUntil timestamp in the MongoDB. (Unless you are in a UTC timezone)
```typescript
import { MongoClient } from 'mongodb';
import { MongoCron } from '../src';
import { promise as sleep } from 'es6-sleep';
import * as moment from 'moment';

(async function() {
  const mongo = await MongoClient.connect('mongodb://localhost:27017', { useNewUrlParser: true });
  const db = mongo.db('test');
  const collection = db.collection('jobs');

  const cron = new MongoCron({
    collection,
    onDocument: (doc) => console.log('onDocument', doc),
    onError: (err) => console.log(err),
    onStart: () => console.log('started ...'),
    onStop: () => console.log('stopped'),
    nextDelay: 1000,
    reprocessDelay: 1000,
    idleDelay: 10000,
    lockDuration: 600000,
    useLocalTime: true // New option
  });

  await collection.insertMany([
    { name: 'Job interval',
      sleepUntil: moment().toDate(),
      interval: '* * 20 * * *'
    }
  ]);

  cron.start();
  await sleep(30000);
  cron.stop();

})().catch(console.error);
```