### PR TITLE
Use typed MongoDB collection

### DIFF
--- a/src/cron.ts
+++ b/src/cron.ts
@@ -3,42 +3,22 @@ import * as dot from 'dot-object';
 import { promise as sleep } from 'es6-sleep';
 import * as moment from 'moment';
 import { Collection } from 'mongodb';
-
-/**
- * Configuration object interface.
- */
-export interface MongoCronCfg {
-  collection: Collection | (() => Collection);
-  condition?: any;
-  nextDelay?: number; // wait before processing next job
-  reprocessDelay?: number; // wait before processing the same job again
-  idleDelay?: number; // when there is no jobs for processing, wait before continue
-  lockDuration?: number; // the time of milliseconds that each job gets locked (we have to make sure that the job completes in that time frame)
-  sleepUntilFieldPath?: string;
-  intervalFieldPath?: string;
-  repeatUntilFieldPath?: string;
-  autoRemoveFieldPath?: string;
-  onDocument?(doc: any): (any | Promise<any>);
-  onStart?(doc: any): (any | Promise<any>);
-  onStop?(): (any | Promise<any>);
-  onIdle?(): (any | Promise<any>);
-  onError?(err: any): (any | Promise<any>);
-}
+import { MongoCronCfg, MongoCronJob } from './types';
 
 /**
  * Main class for converting a collection into cron.
  */
-export class MongoCron {
+export class MongoCron<T = MongoCronJob> {
   protected running = false;
   protected processing = false;
   protected idle = false;
-  protected readonly config: MongoCronCfg;
+  protected readonly config: MongoCronCfg<T>;
 
   /**
    * Class constructor.
    * @param config Configuration object.
    */
-  public constructor(config: MongoCronCfg) {
+  public constructor(config: MongoCronCfg<T>) {
     this.config = {
       onDocument: (doc) => doc,
       onError: console.error,
@@ -46,10 +26,10 @@ export class MongoCron {
       reprocessDelay: 0,
       idleDelay: 0,
       lockDuration: 600000,
-      sleepUntilFieldPath: 'sleepUntil',
-      intervalFieldPath: 'interval',
-      repeatUntilFieldPath: 'repeatUntil',
-      autoRemoveFieldPath: 'autoRemove',
+      sleepUntilFieldPath: 'sleepUntil' as string & keyof T,
+      intervalFieldPath: 'interval' as string & keyof T,
+      repeatUntilFieldPath: 'repeatUntil' as string & keyof T,
+      autoRemoveFieldPath: 'autoRemove' as string & keyof T,
       ...config,
     };
   }
@@ -58,7 +38,7 @@ export class MongoCron {
    * Returns the collection instance (the collection can be provided in
    * the config as an instance or a function).
    */
-  protected getCollection(): Collection {
+  protected getCollection(): Collection<T> {
     return typeof this.config.collection === 'function'
       ? this.config.collection()
       : this.config.collection;
@@ -158,17 +138,21 @@ export class MongoCron {
     const sleepUntil = moment().add(this.config.lockDuration, 'milliseconds').toDate();
     const currentDate = moment().toDate();
 
-    const res = await this.getCollection().findOneAndUpdate({
-      $and: [
-        { [this.config.sleepUntilFieldPath]: { $exists: true, $ne: null }},
-        { [this.config.sleepUntilFieldPath]: { $not: { $gt: currentDate } } },
-        this.config.condition,
-      ].filter((c) => !!c),
-    }, {
-      $set: { [this.config.sleepUntilFieldPath]: sleepUntil },
-    }, {
-      returnDocument: 'before', // return original document to calculate next start based on the original value
-    });
+    const res = await this.getCollection().findOneAndUpdate(
+      {
+        $and: [
+          { [this.config.sleepUntilFieldPath]: { $exists: true, $ne: null } },
+          { [this.config.sleepUntilFieldPath]: { $not: { $gt: currentDate } } },
+          this.config.condition,
+        ].filter((c) => !!c),
+      },
+      {
+        $set: { [this.config.sleepUntilFieldPath]: sleepUntil } as any,
+      },
+      {
+        returnDocument: 'before', // return original document to calculate next start based on the original value
+      },
+    );
     return res.value;
   }
 
@@ -209,15 +193,22 @@ export class MongoCron {
 
     if (!nextStart && dot.pick(this.config.autoRemoveFieldPath, doc)) { // remove if auto-removable and not recuring
       await this.getCollection().deleteOne({ _id });
-    } else if (!nextStart) { // stop execution
-      await this.getCollection().updateOne({ _id }, {
-        $set: { [this.config.sleepUntilFieldPath]: null },
-      });
-    } else { // reschedule for reprocessing in the future (recurring)
-      await this.getCollection().updateOne({ _id }, {
-        $set: { [this.config.sleepUntilFieldPath]: nextStart },
-      });
+    } else if (!nextStart) {
+      // stop execution
+      await this.getCollection().updateOne(
+        { _id },
+        {
+          $set: { [this.config.sleepUntilFieldPath]: null } as any,
+        },
+      );
+    } else {
+      // reschedule for reprocessing in the future (recurring)
+      await this.getCollection().updateOne(
+        { _id },
+        {
+          $set: { [this.config.sleepUntilFieldPath]: nextStart } as any,
+        },
+      );
     }
   }
-
 }

--- a/src/cron.ts
+++ b/src/cron.ts
@@ -2,7 +2,7 @@ import * as parser from 'cron-parser';
 import * as dot from 'dot-object';
 import { promise as sleep } from 'es6-sleep';
 import * as moment from 'moment';
-import { Collection } from 'mongodb';
+import { Collection, WithId } from 'mongodb';
 import { MongoCronCfg, MongoCronJob } from './types';
 
 /**
@@ -157,7 +157,7 @@ export class MongoCron<T = MongoCronJob> {
    * job has expired.
    * @param doc Mongo document.
    */
-  protected getNextStart(doc: any): Date {
+  protected getNextStart(doc: WithId<T>): Date {
     if (!dot.pick(this.config.intervalFieldPath, doc)) { // not recurring job
       return null;
     }
@@ -183,9 +183,9 @@ export class MongoCron<T = MongoCronJob> {
    * if `autoRemove` is set to `true`.
    * @param doc Mongo document.
    */
-  public async reschedule(doc: any): Promise<void> {
+  public async reschedule(doc: WithId<T>): Promise<void> {
     const nextStart = this.getNextStart(doc);
-    const _id = doc._id;
+    const _id = (doc as any)._id;
 
     if (!nextStart && dot.pick(this.config.autoRemoveFieldPath, doc)) { // remove if auto-removable and not recuring
       await this.getCollection().deleteOne({ _id });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export * from './cron';
+export * from './types';

--- a/src/tests/cron.test.ts
+++ b/src/tests/cron.test.ts
@@ -7,7 +7,7 @@ import { MongoCron, MongoCronJob } from '..';
 const spec = new Spec<{
   db: Db;
   mongo: MongoClient;
-  collection: Collection<MongoCronJob & { handle?: true }>;
+  collection: Collection<MongoCronJob & { handle?: boolean }>;
 }>();
 
 spec.before(async (stage) => {

--- a/src/tests/cron.test.ts
+++ b/src/tests/cron.test.ts
@@ -2,12 +2,12 @@ import { Spec } from '@hayspec/spec';
 import { promise as sleep } from 'es6-sleep';
 import * as moment from 'moment';
 import { Collection, Db, MongoClient } from 'mongodb';
-import { MongoCron } from '..';
+import { MongoCron, MongoCronJob } from '..';
 
 const spec = new Spec<{
   db: Db;
   mongo: MongoClient;
-  collection: Collection;
+  collection: Collection<MongoCronJob & { handle?: true }>;
 }>();
 
 spec.before(async (stage) => {
@@ -213,7 +213,7 @@ spec.test('document should stop recurring at `repeatUntil`', async (ctx) => {
   const cron = new MongoCron({
     collection,
     lockDuration: 0,
-    onDocument: async (doc) => repeated = moment(),
+    onDocument: async (doc) => (repeated = moment()),
     reprocessDelay: 1000,
   });
   await cron.start();

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { Collection } from 'mongodb';
+import { Collection, ObjectId } from 'mongodb';
 
 /**
  * Default document type

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,32 @@
+import { Collection } from 'mongodb';
+
+/**
+ * Default document type
+ */
+export interface MongoCronJob {
+  sleepUntil: null | Date;
+  interval?: string;
+  repeatUntil?: Date;
+  autoRemove?: boolean;
+}
+
+/**
+ * Configuration object interface.
+ */
+export interface MongoCronCfg<T = MongoCronJob> {
+  collection: Collection<T> | (() => Collection<T>);
+  condition?: any;
+  nextDelay?: number; // wait before processing next job
+  reprocessDelay?: number; // wait before processing the same job again
+  idleDelay?: number; // when there is no jobs for processing, wait before continue
+  lockDuration?: number; // the time of milliseconds that each job gets locked (we have to make sure that the job completes in that time frame)
+  sleepUntilFieldPath?: string & keyof T;
+  intervalFieldPath?: string & keyof T;
+  repeatUntilFieldPath?: string & keyof T;
+  autoRemoveFieldPath?: string & keyof T;
+  onDocument?(doc: any): any | Promise<any>;
+  onStart?(doc: any): any | Promise<any>;
+  onStop?(): any | Promise<any>;
+  onIdle?(): any | Promise<any>;
+  onError?(err: any): any | Promise<any>;
+}


### PR DESCRIPTION
* added default `MongoCronJob` type which is exported so jobs can be created more comfortably using a typed collection
* moved types to `types.ts`
* changed base class to `MongoCron<T = MongoCronJob>`

There are some places in `cron.ts` that use `as any` because the configuration allows overwriting the field names for the document type.
